### PR TITLE
Updated seconds to midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.2.1 - April 12, 2023
 
-* Updated minutes to midnight value from 100->90 per Jan 2023 decision (https://thebulletin.org/2023/01/press-release-doomsday-clock-set-at-90-seconds-to-midnight/)
+* Updated minutes to midnight value from 100->90 per January 2023 decision (https://thebulletin.org/2023/01/press-release-doomsday-clock-set-at-90-seconds-to-midnight/)
 * Updated README to reflect change, fixed typo.
 
 # 0.2.0 - January 26, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.1 - April 12, 2023
+
+* Updated minutes to midnight value from 100->90 per Jan 2023 decision (https://thebulletin.org/2023/01/press-release-doomsday-clock-set-at-90-seconds-to-midnight/)
+* Updated README to reflect change, fixed typo.
+
 # 0.2.0 - January 26, 2017
 
 * Fixed for half minutes

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ $ npm install minutes-to-midnight
 ```js
 const m2m = require('minutes-to-midnight');
 
-m2m.getSeconds(); // 100 (number)
+m2m.getSeconds(); // 90 (number)
 m2m.getMinutes(); // 1 (number)
-m2m.getFractionalMinutes(); // 1.6666666666666667 (number)
+m2m.getFractionalMinutes(); // 1.5 (number)
 
-m2m.getTimeToMidnight(); // '100 seconds' (string)
-m2m..getTime(); // '11:58:20 PM' (string)
+m2m.getTimeToMidnight(); // '90 seconds' (string)
+m2m.getTime(); // '11:58:30 PM' (string)
 ```
 
 [Doomsday clock]: http://en.wikipedia.org/wiki/Doomsday_Clock

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
      * @return Second to midnight as a number.
      */
     getSeconds() {
-        return 100;
+        return 90;
     },
 
     /**
@@ -27,13 +27,13 @@ module.exports = {
      * @return Time to midnight as a display string.
      */
     getTimeToMidnight() {
-        return '100 seconds';
+        return '90 seconds';
     },
 
     /**
      * @return Current time as a display string;
      */
     getTime() {
-        return '11:58:20 PM';
+        return '11:58:30 PM';
     },
 };


### PR DESCRIPTION
Updated seconds to midnight from 90 to 100 per the Bullentin's announcement in January 2023. 
Updated code in index.js, updated "output comments" in README, fixed typo in README.
Updated change log with these changes - decided this should be 0.2.1. 